### PR TITLE
Fix ci errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,7 @@
   "ignorePatterns": [
     "**/dist/*",
     "**/rollup.config.js",
-    "**/vite-env.d.ts"
+    "**/vite-env.d.ts",
+    "docs/**/*"
   ]
 }

--- a/docs/functions/_userback_react.useUserback.html
+++ b/docs/functions/_userback_react.useUserback.html
@@ -20,7 +20,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">UserbackFunctions</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L126">widget-react/react.tsx:126</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L128">widget-react/react.tsx:128</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/_userback_react.useUserbackContext.html
+++ b/docs/functions/_userback_react.useUserbackContext.html
@@ -20,7 +20,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">UserbackFunctions</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L117">widget-react/react.tsx:117</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L119">widget-react/react.tsx:119</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/_userback_react.withUserback.html
+++ b/docs/functions/_userback_react.withUserback.html
@@ -43,7 +43,7 @@
 <h5>props: <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;userback&quot;</span><span class="tsd-signature-symbol">&gt;</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Element</span></h4></li></ul></li></ul><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L135">widget-react/react.tsx:135</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L137">widget-react/react.tsx:137</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/_userback_widget.default.html
+++ b/docs/functions/_userback_widget.default.html
@@ -27,7 +27,7 @@
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> options: <a href="../interfaces/_userback_widget.UserbackOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L140">widget-js/widget.ts:140</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L144">widget-js/widget.ts:144</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/_userback_widget.getUserback.html
+++ b/docs/functions/_userback_widget.getUserback.html
@@ -22,7 +22,7 @@
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L184">widget-js/widget.ts:184</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L191">widget-js/widget.ts:191</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/_userback_react.WithUserbackProps.html
+++ b/docs/interfaces/_userback_react.WithUserbackProps.html
@@ -19,7 +19,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">WithUserbackProps</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L128">widget-react/react.tsx:128</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L130">widget-react/react.tsx:130</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -35,7 +35,7 @@
 <h3 class="tsd-anchor-link"><span>userback</span><a href="#userback" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">userback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">UserbackFunctions</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L129">widget-react/react.tsx:129</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L131">widget-react/react.tsx:131</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/_userback_widget.UserbackFunctions.html
+++ b/docs/interfaces/_userback_widget.UserbackFunctions.html
@@ -21,7 +21,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L93">widget-js/widget.ts:93</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L94">widget-js/widget.ts:94</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -66,7 +66,7 @@
 <h5>value: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L108">widget-js/widget.ts:108</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L109">widget-js/widget.ts:109</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="close" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>close</span><a href="#close" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -79,7 +79,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L98">widget-js/widget.ts:98</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L99">widget-js/widget.ts:99</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="destroy" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>destroy</span><a href="#destroy" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">destroy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -92,7 +92,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L99">widget-js/widget.ts:99</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L100">widget-js/widget.ts:100</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="hide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>hide</span><a href="#hide" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">hide<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -105,7 +105,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L96">widget-js/widget.ts:96</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L97">widget-js/widget.ts:97</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="identify" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>identify</span><a href="#identify" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">identify<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>user_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, user_info<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -125,7 +125,7 @@
 <h5>user_info: <span class="tsd-signature-type">Object</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L107">widget-js/widget.ts:107</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L108">widget-js/widget.ts:108</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="init" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>init</span><a href="#init" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, options<span class="tsd-signature-symbol">: </span><a href="_userback_widget.UserbackOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -145,7 +145,7 @@
 <h5>options: <a href="_userback_widget.UserbackOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L94">widget-js/widget.ts:94</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L95">widget-js/widget.ts:95</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="isLoaded" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>is<wbr/>Loaded</span><a href="#isLoaded" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is<wbr/>Loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span></div>
@@ -158,7 +158,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L100">widget-js/widget.ts:100</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L101">widget-js/widget.ts:101</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="open" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>open</span><a href="#open" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>feedback_type<span class="tsd-signature-symbol">?: </span><a href="../types/_userback_widget.UserbackFeedbackType.html" class="tsd-signature-type" data-tsd-kind="Type alias">UserbackFeedbackType</a>, destination<span class="tsd-signature-symbol">?: </span><a href="../types/_userback_widget.UserbackDestinationType.html" class="tsd-signature-type" data-tsd-kind="Type alias">UserbackDestinationType</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -178,7 +178,7 @@
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> destination: <a href="../types/_userback_widget.UserbackDestinationType.html" class="tsd-signature-type" data-tsd-kind="Type alias">UserbackDestinationType</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L97">widget-js/widget.ts:97</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L98">widget-js/widget.ts:98</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="openPortal" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>open<wbr/>Portal</span><a href="#openPortal" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<wbr/>Portal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -191,7 +191,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L102">widget-js/widget.ts:102</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L103">widget-js/widget.ts:103</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="setCategories" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Categories</span><a href="#setCategories" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Categories<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>categories<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -209,7 +209,7 @@
 <h5>categories: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L105">widget-js/widget.ts:105</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L106">widget-js/widget.ts:106</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="setData" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Data</span><a href="#setData" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>custom_data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -231,7 +231,7 @@
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L114">widget-js/widget.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L115">widget-js/widget.ts:115</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="setEmail" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Email</span><a href="#setEmail" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>email<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -249,7 +249,7 @@
 <h5>email: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L104">widget-js/widget.ts:104</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L105">widget-js/widget.ts:105</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="setName" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Name</span><a href="#setName" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -267,7 +267,7 @@
 <h5>name: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L103">widget-js/widget.ts:103</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L104">widget-js/widget.ts:104</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="setPriority" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Priority</span><a href="#setPriority" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Priority<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>priority<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -285,7 +285,7 @@
 <h5>priority: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L106">widget-js/widget.ts:106</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L107">widget-js/widget.ts:107</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="show" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>show</span><a href="#show" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">show<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -298,7 +298,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L95">widget-js/widget.ts:95</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L96">widget-js/widget.ts:96</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/_userback_widget.UserbackOptions.html
+++ b/docs/interfaces/_userback_widget.UserbackOptions.html
@@ -21,7 +21,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L62">widget-js/widget.ts:62</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L63">widget-js/widget.ts:63</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -63,72 +63,72 @@
 <h5>data: <span class="tsd-signature-type">UserbackAfterSendData</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L88">widget-js/widget.ts:88</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L89">widget-js/widget.ts:89</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="before_send" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>before_<wbr/>send</span><a href="#before_send" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">before_<wbr/>send<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L86">widget-js/widget.ts:86</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L87">widget-js/widget.ts:87</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="categories" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>categories</span><a href="#categories" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">categories<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L68">widget-js/widget.ts:68</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L69">widget-js/widget.ts:69</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="custom_data" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>custom_<wbr/>data</span><a href="#custom_data" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">custom_<wbr/>data<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">any</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L71">widget-js/widget.ts:71</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L72">widget-js/widget.ts:72</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="domain" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>domain</span><a href="#domain" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">domain<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L78">widget-js/widget.ts:78</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L79">widget-js/widget.ts:79</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="email" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email</span><a href="#email" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L64">widget-js/widget.ts:64</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L65">widget-js/widget.ts:65</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="is_live" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>is_<wbr/>live</span><a href="#is_live" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is_<wbr/>live<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L73">widget-js/widget.ts:73</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L74">widget-js/widget.ts:74</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>name</span><a href="#name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L66">widget-js/widget.ts:66</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L67">widget-js/widget.ts:67</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="native_screenshot" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>native_<wbr/>screenshot</span><a href="#native_screenshot" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">native_<wbr/>screenshot<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L77">widget-js/widget.ts:77</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L78">widget-js/widget.ts:78</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="on_close" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>close</span><a href="#on_close" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>close<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L84">widget-js/widget.ts:84</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L85">widget-js/widget.ts:85</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="on_load" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>load</span><a href="#on_load" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>load<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L80">widget-js/widget.ts:80</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L81">widget-js/widget.ts:81</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="on_open" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>open</span><a href="#on_open" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>open<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L82">widget-js/widget.ts:82</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L83">widget-js/widget.ts:83</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="priority" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>priority</span><a href="#priority" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">priority<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L70">widget-js/widget.ts:70</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L71">widget-js/widget.ts:71</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="widget_settings" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>widget_<wbr/>settings</span><a href="#widget_settings" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">widget_<wbr/>settings<span class="tsd-signature-symbol">?:</span> <a href="_userback_widget.UserbackWidgetSettings.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidgetSettings</a></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L75">widget-js/widget.ts:75</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L76">widget-js/widget.ts:76</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/_userback_widget.UserbackWidget.html
+++ b/docs/interfaces/_userback_widget.UserbackWidget.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">UserbackWidget</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L117">widget-js/widget.ts:117</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L118">widget-js/widget.ts:118</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -68,7 +68,7 @@
 <h3 class="tsd-anchor-link"><span>access_<wbr/>token</span><a href="#access_token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">access_<wbr/>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L119">widget-js/widget.ts:119</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L120">widget-js/widget.ts:120</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="addHeader" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>add<wbr/>Header</span><a href="#addHeader" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">add<wbr/>Header<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>key<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -89,7 +89,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#addHeader">addHeader</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L108">widget-js/widget.ts:108</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L109">widget-js/widget.ts:109</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="after_send" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>after_<wbr/>send</span><a href="#after_send" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">after_<wbr/>send<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">UserbackAfterSendData</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span></div>
@@ -108,19 +108,19 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#after_send">after_send</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L88">widget-js/widget.ts:88</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L89">widget-js/widget.ts:89</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="before_send" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>before_<wbr/>send</span><a href="#before_send" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">before_<wbr/>send<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#before_send">before_send</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L86">widget-js/widget.ts:86</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L87">widget-js/widget.ts:87</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="categories" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>categories</span><a href="#categories" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">categories<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#categories">categories</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L68">widget-js/widget.ts:68</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L69">widget-js/widget.ts:69</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="close" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>close</span><a href="#close" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">close<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -134,13 +134,13 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#close">close</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L98">widget-js/widget.ts:98</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L99">widget-js/widget.ts:99</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="custom_data" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>custom_<wbr/>data</span><a href="#custom_data" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">custom_<wbr/>data<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">any</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#custom_data">custom_data</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L71">widget-js/widget.ts:71</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L72">widget-js/widget.ts:72</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="destroy" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>destroy</span><a href="#destroy" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">destroy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -154,19 +154,19 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#destroy">destroy</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L99">widget-js/widget.ts:99</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L100">widget-js/widget.ts:100</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="domain" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>domain</span><a href="#domain" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">domain<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#domain">domain</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L78">widget-js/widget.ts:78</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L79">widget-js/widget.ts:79</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="email" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email</span><a href="#email" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#email">email</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L64">widget-js/widget.ts:64</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L65">widget-js/widget.ts:65</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="hide" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>hide</span><a href="#hide" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">hide<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -180,7 +180,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#hide">hide</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L96">widget-js/widget.ts:96</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L97">widget-js/widget.ts:97</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="identify" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>identify</span><a href="#identify" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">identify<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>user_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, user_info<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -201,7 +201,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#identify">identify</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L107">widget-js/widget.ts:107</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L108">widget-js/widget.ts:108</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="init" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>init</span><a href="#init" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, options<span class="tsd-signature-symbol">: </span><a href="_userback_widget.UserbackOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -222,7 +222,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#init">init</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L94">widget-js/widget.ts:94</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L95">widget-js/widget.ts:95</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="isLoaded" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>is<wbr/>Loaded</span><a href="#isLoaded" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is<wbr/>Loaded<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span></div>
@@ -236,43 +236,43 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#isLoaded">isLoaded</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L100">widget-js/widget.ts:100</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L101">widget-js/widget.ts:101</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="is_live" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>is_<wbr/>live</span><a href="#is_live" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is_<wbr/>live<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#is_live">is_live</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L73">widget-js/widget.ts:73</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L74">widget-js/widget.ts:74</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>name</span><a href="#name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#name">name</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L66">widget-js/widget.ts:66</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L67">widget-js/widget.ts:67</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="native_screenshot" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>native_<wbr/>screenshot</span><a href="#native_screenshot" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">native_<wbr/>screenshot<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#native_screenshot">native_screenshot</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L77">widget-js/widget.ts:77</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L78">widget-js/widget.ts:78</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="on_close" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>close</span><a href="#on_close" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>close<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#on_close">on_close</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L84">widget-js/widget.ts:84</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L85">widget-js/widget.ts:85</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="on_load" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>load</span><a href="#on_load" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>load<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#on_load">on_load</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L80">widget-js/widget.ts:80</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L81">widget-js/widget.ts:81</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="on_open" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on_<wbr/>open</span><a href="#on_open" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on_<wbr/>open<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Function</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#on_open">on_open</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L82">widget-js/widget.ts:82</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L83">widget-js/widget.ts:83</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="open" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>open</span><a href="#open" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>feedback_type<span class="tsd-signature-symbol">?: </span><a href="../types/_userback_widget.UserbackFeedbackType.html" class="tsd-signature-type" data-tsd-kind="Type alias">UserbackFeedbackType</a>, destination<span class="tsd-signature-symbol">?: </span><a href="../types/_userback_widget.UserbackDestinationType.html" class="tsd-signature-type" data-tsd-kind="Type alias">UserbackDestinationType</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -293,7 +293,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#open">open</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L97">widget-js/widget.ts:97</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L98">widget-js/widget.ts:98</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="openPortal" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>open<wbr/>Portal</span><a href="#openPortal" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<wbr/>Portal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -307,18 +307,18 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#openPortal">openPortal</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L102">widget-js/widget.ts:102</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L103">widget-js/widget.ts:103</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="priority" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>priority</span><a href="#priority" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">priority<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#priority">priority</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L70">widget-js/widget.ts:70</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L71">widget-js/widget.ts:71</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="request_url" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>request_<wbr/>url</span><a href="#request_url" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">request_<wbr/>url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L120">widget-js/widget.ts:120</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L121">widget-js/widget.ts:121</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="setCategories" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Categories</span><a href="#setCategories" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Categories<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>categories<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -337,7 +337,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#setCategories">setCategories</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L105">widget-js/widget.ts:105</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L106">widget-js/widget.ts:106</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="setData" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Data</span><a href="#setData" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>custom_data<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -360,7 +360,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#setData">setData</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L114">widget-js/widget.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L115">widget-js/widget.ts:115</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="setEmail" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Email</span><a href="#setEmail" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>email<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -379,7 +379,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#setEmail">setEmail</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L104">widget-js/widget.ts:104</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L105">widget-js/widget.ts:105</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="setName" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Name</span><a href="#setName" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -398,7 +398,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#setName">setName</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L103">widget-js/widget.ts:103</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L104">widget-js/widget.ts:104</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="setPriority" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set<wbr/>Priority</span><a href="#setPriority" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">set<wbr/>Priority<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>priority<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -417,7 +417,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#setPriority">setPriority</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L106">widget-js/widget.ts:106</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L107">widget-js/widget.ts:107</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="show" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>show</span><a href="#show" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">show<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span></div>
@@ -431,13 +431,13 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackFunctions.html">UserbackFunctions</a>.<a href="_userback_widget.UserbackFunctions.html#show">show</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L95">widget-js/widget.ts:95</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L96">widget-js/widget.ts:96</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="widget_settings" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>widget_<wbr/>settings</span><a href="#widget_settings" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">widget_<wbr/>settings<span class="tsd-signature-symbol">?:</span> <a href="_userback_widget.UserbackWidgetSettings.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidgetSettings</a></div><aside class="tsd-sources">
 <p>Inherited from <a href="_userback_widget.UserbackOptions.html">UserbackOptions</a>.<a href="_userback_widget.UserbackOptions.html#widget_settings">widget_settings</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L75">widget-js/widget.ts:75</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L76">widget-js/widget.ts:76</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/_userback_widget.UserbackWidgetSettings.html
+++ b/docs/interfaces/_userback_widget.UserbackWidgetSettings.html
@@ -19,7 +19,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">UserbackWidgetSettings</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L42">widget-js/widget.ts:42</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L43">widget-js/widget.ts:43</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -65,7 +65,7 @@
 <li class="tsd-parameter">
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> trigger_<wbr/>type<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">&quot;page_load&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;api&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;url_match&quot;</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L43">widget-js/widget.ts:43</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L44">widget-js/widget.ts:44</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/modules/_userback_react.UserbackProvider.html
+++ b/docs/modules/_userback_react.UserbackProvider.html
@@ -15,8 +15,8 @@
 <li><a href="_userback_react.UserbackProvider.html">UserbackProvider</a></li></ul>
 <h1>Namespace UserbackProvider</h1></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L25">widget-react/react.tsx:25</a></li>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L112">widget-react/react.tsx:112</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L27">widget-react/react.tsx:27</a></li>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L114">widget-react/react.tsx:114</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <h3 class="tsd-index-heading uppercase">Index</h3>

--- a/docs/modules/_userback_react.html
+++ b/docs/modules/_userback_react.html
@@ -14,7 +14,7 @@
 <li><a href="_userback_react.html">@userback/react</a></li></ul>
 <h1>Module @userback/react</h1></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L1">widget-react/react.tsx:1</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L2">widget-react/react.tsx:2</a></li></ul></aside>
 <section class="tsd-panel-group">
 <section class="tsd-panel tsd-typography">
 <a href="#userbackreact" id="userbackreact" style="color: inherit; text-decoration: none;">

--- a/docs/modules/_userback_widget.html
+++ b/docs/modules/_userback_widget.html
@@ -14,7 +14,7 @@
 <li><a href="_userback_widget.html">@userback/widget</a></li></ul>
 <h1>Module @userback/widget</h1></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L2">widget-js/widget.ts:2</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L3">widget-js/widget.ts:3</a></li></ul></aside>
 <section class="tsd-panel-group">
 <section class="tsd-panel tsd-typography">
 <a href="#userbackwidget" id="userbackwidget" style="color: inherit; text-decoration: none;">

--- a/docs/types/_userback_widget.UserbackDestinationType.html
+++ b/docs/types/_userback_widget.UserbackDestinationType.html
@@ -16,7 +16,7 @@
 <h1>Type alias UserbackDestinationType</h1></div>
 <div class="tsd-signature">Userback<wbr/>Destination<wbr/>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;screenshot&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;video&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;form&quot;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L92">widget-js/widget.ts:92</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L93">widget-js/widget.ts:93</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/_userback_widget.UserbackFeedbackType.html
+++ b/docs/types/_userback_widget.UserbackFeedbackType.html
@@ -16,7 +16,7 @@
 <h1>Type alias UserbackFeedbackType</h1></div>
 <div class="tsd-signature">Userback<wbr/>Feedback<wbr/>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;general&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;bug&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;feature_request&quot;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L91">widget-js/widget.ts:91</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L92">widget-js/widget.ts:92</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/variables/_userback_react.UserbackProvider.defaultProps.html
+++ b/docs/variables/_userback_react.UserbackProvider.defaultProps.html
@@ -17,7 +17,7 @@
 <h1>Variable defaultProps</h1></div>
 <div class="tsd-signature">default<wbr/>Props<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">PropsWithChildren</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserbackReactProps</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L112">widget-react/react.tsx:112</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-react/react.tsx#L114">widget-react/react.tsx:114</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">


### PR DESCRIPTION
Happened because docs wasn't eslint ignored and clashed with adding
linting to the build action.

Also some linting changes lead to some extra lines which changes how the
docs link source code.