### PR TITLE
remove deprecated defaultProps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,6 @@
     "indent": ["warn", 4],
     "react/jsx-filename-extension": ["off"],
     "max-len": ["warn", 140],
-    "no-use-before-define": ["warn"],
     "no-unused-vars": ["warn"],
     "consistent-return": ["warn"],
     "camelcase": ["off"],
@@ -34,7 +33,8 @@
     "import/extensions": ["off"],
     "@typescript-eslint/ban-ts-comment": "off",
     "no-use-before-define": ["off"],
-    "react/function-component-definition": ["off"]
+    "react/function-component-definition": ["off"],
+    "react/require-default-props": ["off"]
   },
   "root": true,
   "ignorePatterns": [

--- a/widget-react/react.tsx
+++ b/widget-react/react.tsx
@@ -26,7 +26,7 @@ const UserbackContext = createContext<UserbackFunctions | undefined>(
  */
 export const UserbackProvider: React.FC<React.PropsWithChildren<UserbackReactProps>> = ({
     token,
-    options,
+    options = {},
     widgetSettings: widget_settings,
     children,
 }) => {
@@ -109,11 +109,6 @@ export const UserbackProvider: React.FC<React.PropsWithChildren<UserbackReactPro
     ]);
 
     return (<UserbackContext.Provider value={providerValue}>{children}</UserbackContext.Provider>);
-};
-
-UserbackProvider.defaultProps = {
-    options: {},
-    widgetSettings: undefined,
 };
 
 export const useUserbackContext = () => {


### PR DESCRIPTION
defaultProps are being deprecated in a future version of React. This results in an error message in my console for every page load when using the react widget.

This PR simply replaces the default props with JS default parameters instead