### PR TITLE
v0.2.0

### DIFF
--- a/.yarn/versions/16f79a3d.yml
+++ b/.yarn/versions/16f79a3d.yml
@@ -2,8 +2,12 @@ undecided:
   - root
   - e2e
   - example-js
+  - example-nuxt
+  - example-nuxt2
   - example-react
   - example-react-class
   - example-vue
+  - example-vue2
   - "@userback/widget"
   - "@userback/react"
+  - "@userback/vue"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "test": "playwright test"

--- a/examples/js/package.json
+++ b/examples/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-js",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-nuxt",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "nuxt build",

--- a/examples/nuxt2/package.json
+++ b/examples/nuxt2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-nuxt2",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/react-class/package.json
+++ b/examples/react-class/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-class",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "scripts": {
     "start": "vite",
     "build": "tsc --noEmit && vite build",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vue",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vue2",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "scripts": {
     "start": "vite",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "description": "Root workspace for userback.io npm packages",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/widget-js/package.json
+++ b/widget-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@userback/widget",
   "description": "Userback.io widget for Javascript and Typescript",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/widget.mjs",
   "module": "dist/widget.mjs",

--- a/widget-react/package.json
+++ b/widget-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@userback/react",
   "description": "Userback.io widget for React",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/react.cjs",
   "module": "dist/react.mjs",

--- a/widget-vue/package.json
+++ b/widget-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@userback/vue",
   "description": "Userback.io widget for Vue3",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/vue.cjs",
   "module": "dist/vue.mjs",

--- a/widget-vue2/package.json
+++ b/widget-vue2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@userback/vue2",
   "description": "Userback.io widget for Vue2",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/vue.cjs",
   "module": "dist/vue.mjs",


### PR DESCRIPTION
- Add support for `vue2` with `@userback/vue2` (#42 )
- Add examples for `nuxt2` and `nuxt3` (#43 )
- Remove usage of `.cjs` for `@userback/widget`, fixes issue with webpack4 importing both cjs/mjs modules and breaking (#42 )
- Remove deprecated `React.defaultProps` in favor of optional params - Thanks @eluce2 (#40 )
- npm package updates and misc development improvements