### PR TITLE
Adds exports to package.json

### DIFF
--- a/widget-js/package.json
+++ b/widget-js/package.json
@@ -3,6 +3,14 @@
   "description": "Userback.io widget for Javascript and Typescript",
   "version": "0.2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/widget.mjs",
+      "require": "./dist/widget.cjs",
+      "types": "./dist/widget.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/widget.mjs",
   "module": "dist/widget.mjs",
   "umd": "dist/widget.umd.js",

--- a/widget-react/package.json
+++ b/widget-react/package.json
@@ -3,6 +3,14 @@
   "description": "Userback.io widget for React",
   "version": "0.2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.cjs",
+      "types": "./dist/react.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/react.cjs",
   "module": "dist/react.mjs",
   "umd": "dist/react.umd.js",

--- a/widget-vue/package.json
+++ b/widget-vue/package.json
@@ -3,6 +3,14 @@
   "description": "Userback.io widget for Vue3",
   "version": "0.2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/vue.mjs",
+      "require": "./dist/vue.cjs",
+      "types": "./dist/vue.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/vue.cjs",
   "module": "dist/vue.mjs",
   "umd": "dist/vue.umd.js",

--- a/widget-vue2/package.json
+++ b/widget-vue2/package.json
@@ -3,6 +3,14 @@
   "description": "Userback.io widget for Vue2",
   "version": "0.2.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/vue.mjs",
+      "require": "./dist/vue.cjs",
+      "types": "./dist/vue.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "dist/vue.cjs",
   "module": "dist/vue.mjs",
   "umd": "dist/vue.umd.js",


### PR DESCRIPTION
solves #45

The new standard for resolving different exports is with the `export` key. https://nodejs.org/api/packages.html#package-entry-points

Some environments will require these to work properly.