### PR TITLE
Use env over secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
-      VITE_UB_TOKEN: ${{ secrets.UB_TOKEN }}
+      VITE_UB_TOKEN: ${{ vars.UB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
Github actions does not allow secrets to be passed to external PR

https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow