### PR TITLE
Delays initialization on React

### DIFF
--- a/widget-js/widget.ts
+++ b/widget-js/widget.ts
@@ -178,9 +178,9 @@ export default function UserbackWidgetLoader(token: string, ubOptions?: Userback
                     if (typeof opts?.on_load === 'function') { opts.on_load(); }
 
                     // Monkeypatch Userback.destroy to ensure we keep our USERBACK reference in sync
-                    const origDestory = USERBACK.destroy;
+                    const origDestroy = USERBACK.destroy;
                     USERBACK.destroy = function proxyDestroy() {
-                        origDestory();
+                        origDestroy();
                         USERBACK = undefined;
                         UBLoadingPromise = undefined;
                     };

--- a/widget-react/react.tsx
+++ b/widget-react/react.tsx
@@ -12,6 +12,7 @@ export interface UserbackReactProps {
   token: string,
   options?: UserbackOptions,
   widgetSettings?: UserbackWidgetSettings,
+  delayInit?: boolean,
 }
 
 const UserbackContext = createContext<UserbackFunctions | undefined>(
@@ -28,24 +29,26 @@ export const UserbackProvider: React.FC<React.PropsWithChildren<UserbackReactPro
     token,
     options = {},
     widgetSettings: widget_settings,
+    delayInit = false,
     children,
 }) => {
     const ubLoaded = useRef(false);
-    const [Userback, setUserback] = useState(undefined as UserbackWidget | undefined);
+    const [Userback, setUserback] = useState<UserbackWidget>();
 
-    const init = useCallback(async (_token: string, _options?: UserbackOptions) => {
+    const init = useCallback(async (_token: string = token, _options: UserbackOptions = { widget_settings, ...options }) => {
+        if (Userback) return Userback;
         ubLoaded.current = true;
         const ub = await UserbackInit(_token, _options);
         setUserback(ub);
         return ub;
-    }, [setUserback]);
+    }, [Userback, token, widget_settings, options]);
 
     // onMount
     useEffect(() => {
-        if (!ubLoaded.current) {
+        if (!ubLoaded.current && !delayInit) {
             init(token, { widget_settings, ...options });
         }
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [delayInit]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Api hooks
     const hide = useCallback(() => { Userback?.hide(); }, [Userback]);


### PR DESCRIPTION
Solves a portion of #21 

This PR:
- Refactors how the main widget package handles multiple calls to `init` using a store promise, allowing multiple calls to init to load only one instance while still having both "succeed" safely
- Provides prop and makes adjustments to React context provider to allow delaying of the initialization with context value passthrough (or init overrides)

I couldn't get tests to work at all locally (not entirely sure the steps needed to even run them as the readme seemed incomplete) so those will need to be checked, and possibly additional tests added for this.