### PR TITLE
Improve error handling for widget loader

### DIFF
--- a/docs/functions/_userback_widget.default.html
+++ b/docs/functions/_userback_widget.default.html
@@ -29,7 +29,7 @@
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> ubOptions: <a href="../interfaces/_userback_widget.UserbackOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L143">widget-js/widget.ts:143</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L147">widget-js/widget.ts:147</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/_userback_widget.getUserback.html
+++ b/docs/functions/_userback_widget.getUserback.html
@@ -24,7 +24,7 @@
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_userback_widget.UserbackWidget.html" class="tsd-signature-type" data-tsd-kind="Interface">UserbackWidget</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L209">widget-js/widget.ts:209</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/userback/widget-js/blob/master/widget-js/widget.ts#L215">widget-js/widget.ts:215</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">


### PR DESCRIPTION
Fixes the Event error handling for the widget loader to pass through the object instead of a stringified version which obscures the error.

Also improve setting undefined on a failed load.